### PR TITLE
Simpler way to import the Vendor class

### DIFF
--- a/View/Helper/PhpExcelHelper.php
+++ b/View/Helper/PhpExcelHelper.php
@@ -192,8 +192,9 @@ class PhpExcelHelper extends AppHelper {
 	 */
 	protected function loadEssentials() {
 		// load vendor class
-		App::import('Vendor', 'PHPExcel', array('file' => 'phpexcel/Classes/PHPExcel.php')); 
-		if (!class_exists('PHPExcel'))
+		App::import('Vendor', 'PHPExcel/Classes/PHPExcel');
+		if (!class_exists('PHPExcel')) {
 			throw new CakeException('Vendor class PHPExcel not found!');
+		}
 	}
 }


### PR DESCRIPTION
The "App::import('Vendor'" didn't work for me. This version is simpler and works as expected.
