### PR TITLE
Make addTableHeader to not generate empty header if empty array passed

### DIFF
--- a/Controller/Component/PhpExcelComponent.php
+++ b/Controller/Component/PhpExcelComponent.php
@@ -215,7 +215,9 @@ class PhpExcelComponent extends Component {
 
             $offset++;
         }
-        $this->_row++;
+        
+        if (count($data))
+            $this->_row++;
 
         return $this;
     }


### PR DESCRIPTION
There were no way currently to correctly initialize the _tableParams member while having no header row.

Passing empty array as a header data initializes the parameters, while not generating an empty header row. I think it gives more expectable result this way and provide ability of creating tables without header row.
