### PR TITLE
calculate cell formulas by default

### DIFF
--- a/View/Helper/PhpExcelHelper.php
+++ b/View/Helper/PhpExcelHelper.php
@@ -338,6 +338,7 @@ class PhpExcelHelper extends AppHelper {
 
         // writer
         $objWriter = $this->getWriter($writer);
+        $objWriter->setPreCalculateFormulas(true);
         $objWriter->save('php://output');
 
         exit;


### PR DESCRIPTION
The 'setPreCalculateFormulas(true)' is needed to save the file with calculated forumulas. Without it if you have cell with formula ex. '=A1+A2' or `=SUM(A1:A2)' the result will be always zero until you reenter/recalculate the cell value once opened in Excel. Took me some time to figure this out, I belive it's the desired behavior for 99% developers who use any kind of formulas in generated spreadsheet so I'd make turned on by default.